### PR TITLE
Custom command

### DIFF
--- a/ custom commands.cy.js
+++ b/ custom commands.cy.js
@@ -1,0 +1,32 @@
+describe('my first test command', () => {
+  it('should login to the application using custom command', function () {
+    
+    function launchApplication() {
+      cy.visit('https://demo.applitools.com/');
+    }
+
+    function enterUsername(username) {
+      cy.get('#username').type(username);
+    }
+
+    
+    function enterPassword(password) {
+      cy.get('#password').type(password);
+    }
+
+    function clickLoginButton() {
+      cy.get('#log-in').click();
+    }
+
+    function verifyLoginSuccess() {
+      cy.contains('logout').click();
+    }
+
+    
+    launchApplication();
+    enterUsername('username');
+    enterPassword('password');
+    clickLoginButton();
+    verifyLoginSuccess();
+  });
+});

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+ I set a test case earlier in one of my projects on playground called slogin.spec.cy.js which is the login for demo.applitools. I was able to add Cypress.Commands.add() to my customCommands.js. within my cypress.io. 
+ This allowed me to set a command for login and password to the www.demo.applitools.com for easier and smoother access to the website and I was able to address the coding error I was getting in the previous test case 
+ slogin.spec.cy.js. Here is an example of my custom command.add() i added to the customCommands.js file.
+ 
+ Cypress.Commands.add("login", (username, password) => {
+    cy.clearCookies();
+    cy.clearLocalStorage();
+    cy.get("#user_login").type(username);
+    cy.get("#user_pass").type(password);
+    cy.contains('log in').click();
+  });

--- a/slogin_spec.cy.js
+++ b/slogin_spec.cy.js
@@ -1,0 +1,28 @@
+function launchApplication() {
+  it('Visits demo.applitools', () => {
+    cy.visit('https://demo.applitools.com/');
+
+    function enterUsername(username) {
+      cy.get('#username').type(username);
+    }
+
+    function enterPassword(password) {
+      cy.get('#password').type(password);
+    }
+
+    function clickLoginButton() {
+      cy.get('button').click();
+    }
+
+    function verifyLoginSuccess() {
+      cy.contains('logout').click();
+    }
+
+    enterUsername('username');
+    enterPassword('password');
+    clickLoginButton();
+    verifyLoginSuccess();
+  });
+}
+
+launchApplication();


### PR DESCRIPTION
 I set a test case earlier in one of my projects on playground called slogin.spec.cy.js which is the login for demo.applitools. I was able to add Cypress.Commands.add() to my customCommands.js. within my cypress.io. 
 This allowed me to set a command for login and password to the www.demo.applitools.com for easier and smoother access to the website and I was able to address the coding error I was getting in the previous test case 
 slogin.spec.cy.js. 